### PR TITLE
Fix: Disable automatic port forwarding in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,6 @@
         "ms-toolsai.jupyter"
       ]
     }
-  }
+  },
+  "forwardPorts": []
 }


### PR DESCRIPTION
This commit disables automatic port forwarding in the devcontainer configuration to prevent errors when no application is listening on the forwarded ports.