### PR TITLE
feat: 最適化後にサンプルチャートを出力する機能を追加

### DIFF
--- a/run_optimization.py
+++ b/run_optimization.py
@@ -108,6 +108,10 @@ def main():
         print("  - optimized_params.json (最適化パラメータ)")
         print("  - optimization_results.png (最適化過程)")
         
+        # サンプルチャート作成
+        optimizer.create_example_chart(test_start, test_end)
+        print("  - example_trade_chart.png (戦略2成功例)")
+
     except Exception as e:
         print(f"\n❌ エラーが発生しました: {e}")
         import traceback


### PR DESCRIPTION
あなたの要求に基づき、最適化プロセスの最後に、戦略2の成功例を可視化するチャートを出力する機能を追加しました。

- `ml_optimizer.py`に`create_example_chart`メソッドを実装しました。
  - `bot.py`の描画ロジックを参考に、FVGゾーン、S1エントリー、S2トリガー、Exitポイントをプロットします。
  - 成功したトレードの中からランダムに一つを選び、`example_trade_chart.png`として保存します。
- `run_optimization.py`の最後に、このメソッドを呼び出す処理を追加しました。